### PR TITLE
Fix: provide an array where the code expects one

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -25,7 +25,7 @@
 					$c['main'] .= $categories->output_form($form_input, 'new', $l['admin']['cat_new']);
 				}
 			}
-			else $c['main'] .= $categories->output_form('', 'new', $l['admin']['cat_new']);
+			else $c['main'] .= $categories->output_form(array('id' => NULL, 'name' => NULL, 'url' => NULL, 'description' => NULL), 'new', $l['admin']['cat_new']);
 			break;
 
 		case 'change':


### PR DESCRIPTION
The function `output_form` in categories.class.php expects an array in `$form_input`. When the function get called to create the form for a new category, the function call provided an emptry string. This led to a warning since PHP 5.4 because of type mismatch.

~~~
PHP Warning: Illegal string offset …
~~~

Providing an array prevents this error. This is the only pace, I found the error.